### PR TITLE
Rename TOKEN_MONITOR_LOG env var to GREENBELT_LOG

### DIFF
--- a/greenbelt.py
+++ b/greenbelt.py
@@ -4,7 +4,7 @@ greenbelt.py — Claude Code token usage hook.
 
 Configured as a Stop hook in .claude/settings.json.
 Reads session data from stdin (JSON), extracts token counts,
-appends a record to ~/.claude/token_usage.jsonl, and prints a summary.
+appends a record to ~/.claude/greenbelt.jsonl, and prints a summary.
 """
 
 import json
@@ -14,8 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 # Where to store accumulated usage records.
-# Defaults to ~/.claude/token_usage.jsonl but can be overridden via env var.
-LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
+# Defaults to ~/.claude/greenbelt.jsonl but can be overridden via env var.
+LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "greenbelt.jsonl"))
 
 # Pricing per 1M tokens (USD) — update when Anthropic changes rates.
 PRICING = {

--- a/greenbelt.py
+++ b/greenbelt.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 # Where to store accumulated usage records.
 # Defaults to ~/.claude/token_usage.jsonl but can be overridden via env var.
-LOG_PATH = Path(os.environ.get("TOKEN_MONITOR_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
+LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
 
 # Pricing per 1M tokens (USD) — update when Anthropic changes rates.
 PRICING = {

--- a/view_tokens.py
+++ b/view_tokens.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-LOG_PATH = Path(os.environ.get("TOKEN_MONITOR_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
+LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
 
 
 def load_records(since: datetime | None = None) -> list[dict]:

--- a/view_tokens.py
+++ b/view_tokens.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "token_usage.jsonl"))
+LOG_PATH = Path(os.environ.get("GREENBELT_LOG", Path.home() / ".claude" / "greenbelt.jsonl"))
 
 
 def load_records(since: datetime | None = None) -> list[dict]:


### PR DESCRIPTION
## Summary
- Renames the `TOKEN_MONITOR_LOG` environment variable override to `GREENBELT_LOG` in both `greenbelt.py` and `view_tokens.py`, completing the rename from `token_monitor` to `greenbelt`

## Test plan
- [ ] Verify `GREENBELT_LOG=/tmp/test.jsonl python3 greenbelt.py` uses the custom path
- [ ] Verify `GREENBELT_LOG=/tmp/test.jsonl python3 view_tokens.py` uses the custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)